### PR TITLE
[WEEK03] add VideoDTO, Controller, Service

### DIFF
--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/MetadataDTO.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/MetadataDTO.java
@@ -1,7 +1,62 @@
 package org.hstack.vmeta.videoMetadata.metadata;
 
-import lombok.Data;
 
-@Data
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hstack.vmeta.videoMetadata.metadata.category.Category;
+import org.hstack.vmeta.videoMetadata.metadata.indexScript.IndexScript;
+import org.hstack.vmeta.videoMetadata.metadata.keyword.Keyword;
+import org.hstack.vmeta.videoMetadata.metadata.narrative.Narrative;
+import org.hstack.vmeta.videoMetadata.metadata.narrative.NarrativeAttributeConverter;
+import org.hstack.vmeta.videoMetadata.metadata.presentation.Presentation;
+import org.hstack.vmeta.videoMetadata.metadata.presentation.PresentationAttributeConverter;
+import org.hstack.vmeta.videoMetadata.metadata.script.Script;
+import org.hstack.vmeta.videoMetadata.metadata.videoFrame.VideoFrame;
+import org.hstack.vmeta.videoMetadata.metadata.videoFrame.VideoFrameAttributeConverter;
+import org.hstack.vmeta.videoMetadata.metadata.videoType.VideoType;
+import org.hstack.vmeta.videoMetadata.metadata.videoType.VideoTypeAttributeConverter;
+
+import java.sql.Date;
+import java.sql.Time;
+import java.util.List;
+
+/*
+ * extraction과 소통할 순수 Metadata
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class MetadataDTO {
+
+    private Long id;
+
+    private String title;
+
+    private String uploaderName;
+
+    private Narrative narrative;
+
+    private Presentation presentation;
+
+    private Time length;
+
+    private Date uploadDate;
+
+    private Long videoSize;
+
+    private VideoType videoType;
+
+    private VideoFrame videoFrame;
+
+    private List<Category> category;
+
+    private List<Script> script;
+
+    private List<Keyword> keyword;
+
+    private List<IndexScript> indexScript;
 }

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/VideoMetadataDTO.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/VideoMetadataDTO.java
@@ -1,4 +1,53 @@
 package org.hstack.vmeta.videoMetadata.metadata;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hstack.vmeta.videoMetadata.metadata.category.Category;
+import org.hstack.vmeta.videoMetadata.metadata.indexScript.IndexScript;
+import org.hstack.vmeta.videoMetadata.metadata.keyword.Keyword;
+import org.hstack.vmeta.videoMetadata.metadata.narrative.Narrative;
+import org.hstack.vmeta.videoMetadata.metadata.presentation.Presentation;
+import org.hstack.vmeta.videoMetadata.metadata.script.Script;
+
+import java.sql.Date;
+import java.sql.Time;
+import java.util.List;
+
+
+/*
+ * search, detailView 등 user에게 보여지는 영역용
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class VideoMetadataDTO {
+
+    private Long Id;
+
+    private String title;
+
+    private String path;
+
+    private String uploaderName;
+
+    private String thumbnailPath;
+
+    private Narrative narrative;
+
+    private Presentation presentation;
+
+    private Time length;
+
+    private Date uploadDdate;
+
+    private List<Category> category;
+
+    private List<Script> script;
+
+    private List<Keyword> keyword;
+
+    private List<IndexScript> indexScript;
 }

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/video/VideoController.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/video/VideoController.java
@@ -27,7 +27,8 @@ public class VideoController {
     public ResponseEntity<?> saveVideo(@RequestBody VideoDTO videoDTO) {
         try {
             Long videoId = videoService.save(videoDTO);
-            return ResponseEntity.ok("save video # ${videoId} - ${videoDTO.title} succeed.");
+            String body = "save video #" + videoId + " succeed.";
+            return ResponseEntity.ok(body);
         } catch (Exception e) {
             return ResponseEntity.internalServerError().build();
         }
@@ -37,7 +38,8 @@ public class VideoController {
     public ResponseEntity<?> deleteVideo(@RequestParam Long videoId) {
         try {
             videoService.delete(videoId);
-            return ResponseEntity.ok("delete video ${videoId} succeed.");
+            String body = "delete video #" + videoId + " succeed.";
+            return ResponseEntity.ok(body);
         } catch (Exception e) {
             return ResponseEntity.internalServerError().build();
         }

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/video/VideoController.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/video/VideoController.java
@@ -1,9 +1,8 @@
 package org.hstack.vmeta.videoMetadata.video;
 
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -11,4 +10,36 @@ import java.util.List;
 @RequestMapping("/video")
 public class VideoController {
 
+    @Autowired
+    private VideoService videoService;
+
+    @GetMapping
+    public ResponseEntity<?> getAllVideo() {
+        try {
+            List<VideoDTO> videoDTOs = videoService.getAll();
+            return ResponseEntity.ok(videoDTOs);
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    @PostMapping
+    public ResponseEntity<?> saveVideo(@RequestBody VideoDTO videoDTO) {
+        try {
+            Long videoId = videoService.save(videoDTO);
+            return ResponseEntity.ok("save video # ${videoId} - ${videoDTO.title} succeed.");
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    @GetMapping("/delete")
+    public ResponseEntity<?> deleteVideo(@RequestParam Long videoId) {
+        try {
+            videoService.delete(videoId);
+            return ResponseEntity.ok("delete video ${videoId} succeed.");
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().build();
+        }
+    }
 }

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/video/VideoController.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/video/VideoController.java
@@ -1,0 +1,14 @@
+package org.hstack.vmeta.videoMetadata.video;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/video")
+public class VideoController {
+
+}

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/video/VideoDTO.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/video/VideoDTO.java
@@ -1,11 +1,19 @@
 package org.hstack.vmeta.videoMetadata.video;
 
-import lombok.Data;
 
-@Data
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class VideoDTO {
 
-    private Long Id;
+    private Long id;
 
     private String title;
 
@@ -13,4 +21,20 @@ public class VideoDTO {
 
     private String thumbnailPath;
 
+    public static VideoDTO video2VideoDTO(Video video) {
+        return VideoDTO.builder()
+                .id(video.getId())
+                .title(video.getTitle())
+                .uploaderName(video.getUploaderName())
+                .thumbnailPath(video.getThumbnailPath())
+                .build();
+    }
+
+    public Video videoDTO2Video() {
+        return Video.builder()
+                .title(this.title)
+                .uploaderName(this.uploaderName)
+                .thumbnailPath(this.thumbnailPath)
+                .build();
+    }
 }

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/video/VideoRepository.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/video/VideoRepository.java
@@ -9,11 +9,11 @@ import java.util.Optional;
 @Repository
 public interface VideoRepository extends JpaRepository<Video, Long> {
 
-    Video save(Video video);
+    Long save(Video video);
 
     Optional<Video> findById(Long id);
 
-    List<Video> findByTitleContains(String title);
+    Optional<Video> findByTitleContains(String title);
 
     void deleteById(Long id);
 

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/video/VideoRepository.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/video/VideoRepository.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 @Repository
 public interface VideoRepository extends JpaRepository<Video, Long> {
 
-    Long save(Video video);
+    Video save(Video video);
 
     Optional<Video> findById(Long id);
 

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/video/VideoService.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/video/VideoService.java
@@ -33,7 +33,7 @@ public class VideoService {
     /*
      * videoDTO의 id를 기준으로 삭제한다.
      */
-    public void delete(VideoDTO videoDTO) {
-        videoRepository.deleteById(videoDTO.getId());
+    public void delete(Long videoId) {
+        videoRepository.deleteById(videoId);
     }
 }

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/video/VideoService.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/video/VideoService.java
@@ -1,0 +1,44 @@
+package org.hstack.vmeta.videoMetadata.video;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class VideoService {
+
+    @Autowired
+    private VideoRepository videoRepository;
+
+    public VideoService(VideoRepository videoRepository) {
+        this.videoRepository = videoRepository;
+    }
+
+    /*
+     * VideoRepository에서 모든 Video를 받아
+     * VideoDTO로 변환 후 반환한다.
+     */
+    public List<VideoDTO> getAll() {
+        return videoRepository.findAll()
+                .stream()
+                .map(v -> VideoDTO.video2VideoDTO(v))
+                .collect(Collectors.toList());
+    }
+
+    /*
+     * videoDTO를 video로 변환 후 저장한다.
+     */
+    public Long save(VideoDTO videoDTO) {
+        return videoRepository.save(videoDTO.videoDTO2Video());
+    }
+
+    /*
+     * videoDTO의 id를 기준으로 삭제한다.
+     */
+    public void delete(VideoDTO videoDTO) {
+        videoRepository.deleteById(videoDTO.getId());
+    }
+}

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/video/VideoService.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/video/VideoService.java
@@ -4,7 +4,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -12,10 +11,6 @@ public class VideoService {
 
     @Autowired
     private VideoRepository videoRepository;
-
-    public VideoService(VideoRepository videoRepository) {
-        this.videoRepository = videoRepository;
-    }
 
     /*
      * VideoRepository에서 모든 Video를 받아
@@ -32,7 +27,7 @@ public class VideoService {
      * videoDTO를 video로 변환 후 저장한다.
      */
     public Long save(VideoDTO videoDTO) {
-        return videoRepository.save(videoDTO.videoDTO2Video());
+        return videoRepository.save(videoDTO.videoDTO2Video()).getId();
     }
 
     /*

--- a/videoMetadata/src/test/java/org/hstack/vmeta/videoMetadata/video/VideoControllerTest.java
+++ b/videoMetadata/src/test/java/org/hstack/vmeta/videoMetadata/video/VideoControllerTest.java
@@ -1,0 +1,28 @@
+package org.hstack.vmeta.videoMetadata.video;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class VideoControllerTest {
+
+    @BeforeEach
+    void init() {
+    }
+
+    @Test
+    void getAllVideo() {
+    }
+
+    @Test
+    void saveVideo() {
+    }
+
+    @Test
+    void deleteVideo() {
+    }
+}

--- a/videoMetadata/src/test/java/org/hstack/vmeta/videoMetadata/video/VideoControllerTest.java
+++ b/videoMetadata/src/test/java/org/hstack/vmeta/videoMetadata/video/VideoControllerTest.java
@@ -1,28 +1,135 @@
 package org.hstack.vmeta.videoMetadata.video;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.ArrayList;
+import java.util.List;
 
-@SpringBootTest
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+@WebMvcTest(VideoController.class)
 class VideoControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    VideoService videoService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    final String baseUrl = "/video";
 
     @BeforeEach
     void init() {
     }
 
     @Test
-    void getAllVideo() {
+    @DisplayName("전체 비디오 조회")
+    void getAllVideo() throws Exception{
+        // given
+        List<VideoDTO> savedVideoDTOList = new ArrayList<>();
+        savedVideoDTOList.add(VideoDTO.builder()
+                .id(1L)
+                .title("testTitle1")
+                .uploaderName("testUploader1")
+                .thumbnailPath("/test/1L/path.mp4")
+                .build());
+        savedVideoDTOList.add(VideoDTO.builder()
+                .id(2L)
+                .title("testTitle2")
+                .uploaderName("testUploader2")
+                .thumbnailPath("/test/2L/path.mp4")
+                .build());
+
+        // mocking
+        given(videoService.getAll()).willReturn(savedVideoDTOList);
+
+        // when
+        final ResultActions actions =
+                mockMvc.perform(
+                        get(baseUrl)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON)
+                                .characterEncoding("UTF-8")
+                );
+
+        // then
+        actions.andExpect(status().isOk())
+                .andExpect(jsonPath("$[0]").exists())
+                .andExpect(jsonPath("$[1]").exists())
+                .andDo(print());
     }
 
     @Test
-    void saveVideo() {
+    @DisplayName("비디오 저장")
+    void saveVideo() throws Exception {
+        // given
+        VideoDTO videoDTO = VideoDTO.builder().title("testTitle").build();
+        Long expectVideoId = 0L;
+
+        // mocking
+        given(videoService.save(videoDTO)).willReturn(expectVideoId);
+
+        // when
+        final ResultActions actions =
+                mockMvc.perform(
+                        post(baseUrl)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(videoDTO))
+                                .characterEncoding("UTF-8")
+                );
+
+        String body = "save video #" + expectVideoId + " succeed.";
+
+        // then
+        actions.andExpect(status().isOk())
+                .andExpect(jsonPath("$").value(body))
+                .andDo(print());
     }
 
     @Test
-    void deleteVideo() {
+    @DisplayName("비디오 삭제")
+    void deleteVideo() throws Exception{
+        // given
+        Long videoId = 1L;
+
+        // mocking
+
+        // when
+        final ResultActions actions =
+                mockMvc.perform(
+                        get(baseUrl + "/delete")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON)
+                                .param("videoId", String.valueOf(videoId))
+                                .characterEncoding("UTF-8")
+                );
+
+
+        String body = "delete video #" + videoId + " succeed.";
+
+        // then
+        actions.andExpect(status().isOk())
+                .andExpect(jsonPath("$").value(body))
+                .andDo(print());
     }
 }

--- a/videoMetadata/src/test/java/org/hstack/vmeta/videoMetadata/video/VideoServiceTest.java
+++ b/videoMetadata/src/test/java/org/hstack/vmeta/videoMetadata/video/VideoServiceTest.java
@@ -1,0 +1,85 @@
+package org.hstack.vmeta.videoMetadata.video;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+
+@SpringBootTest
+class VideoServiceTest {
+
+    @Autowired
+    private VideoRepository videoRepository;
+
+    @Autowired
+    private VideoService videoService;
+
+
+    @BeforeEach
+    void beforeEach() {
+        videoRepository.deleteAll();
+    }
+
+    @Test
+    void getAll() {
+        // given
+        VideoDTO videoDTO1 = VideoDTO.builder()
+                .title("testTitle1")
+                .uploaderName("testUploader1")
+                .build();
+
+        VideoDTO videoDTO2 = VideoDTO.builder()
+                .title("testTitle2")
+                .uploaderName("testUploader2")
+                .build();
+
+        videoService.save(videoDTO1);
+        videoService.save(videoDTO2);
+
+        // when
+        List<VideoDTO> resList = videoService.getAll();
+
+        // then
+        assertThat(resList.size()).isEqualTo(2);
+    }
+
+    @Test
+    void save() {
+        // given
+        VideoDTO videoDTO = VideoDTO.builder()
+                .title("testTitle")
+                .uploaderName("testUploader")
+                .build();
+
+        // when
+        Long newId = videoService.save(videoDTO);
+
+        // then
+        assertThat(newId).isNotNull();
+    }
+
+    @Test
+    void delete() {
+        // given
+        VideoDTO videoDTO = VideoDTO.builder()
+                .id(1L)
+                .title("testTitle")
+                .uploaderName("testUploader")
+                .build();
+
+        videoService.save(videoDTO);
+
+        // when
+        videoService.delete(videoDTO);
+
+        // then
+        assertThat(videoRepository.findById(videoDTO.getId())).isEmpty();
+    }
+}

--- a/videoMetadata/src/test/java/org/hstack/vmeta/videoMetadata/video/VideoServiceTest.java
+++ b/videoMetadata/src/test/java/org/hstack/vmeta/videoMetadata/video/VideoServiceTest.java
@@ -77,7 +77,7 @@ class VideoServiceTest {
         videoService.save(videoDTO);
 
         // when
-        videoService.delete(videoDTO);
+        videoService.delete(videoDTO.getId());
 
         // then
         assertThat(videoRepository.findById(videoDTO.getId())).isEmpty();


### PR DESCRIPTION
###  [12월 2주차 정기] 12/11 ~ 12/15

<hr/>

**1. VideoService 생성**
 → [🛎️videoService 생성](https://www.notion.so/yeondelight/videoService-f6350def1eeb4db08f8cd0c2150e1c25?pvs=4)
- VideoDTO 생성
    - id, title, uploaderName, thumbnailPath로 구성
    - 추후 upload 페이지에서 업로드 진행 상황판 출력시 사용 예정
    - Video - VideoDTO간 변환 : VideoDTO 내에 작성하여 Entity가 DTO에 의존하지 않도록 함
- VideoService 생성
    - getAllVideo(), saveVideo(), deleteVideo()
    - VideoDTO를 받아 VideoRepository에 맞게 처리 후 VideoRepository 내의 함수 호출


<br/>

**2. VideoController 생성**
 → [🎮videoController 생성 및 Test](https://www.notion.so/yeondelight/videoController-Test-1c4da48b30324fdfaebab375f989e1b2?pvs=4)
 - @ RestController를 이용하여 모든 결과값을 json으로 반환
    - /video
        - [get] getAllVideo() : Repository 내 모든 Video를 List<VideoDTO>로 반환
        - [post] saveVideo() : 전달받은 VideoDTO를 Repository를 통해 저장
    - /video/delete
        - [get] deleteVideo() : @ RequestParam으로 전달받은 id에 해당하는 Video를 Repository에서 삭제한다.
        - 

<br/>

**3. VideoController, VideoService Test**
 → [🛎️videoService Test](https://www.notion.so/yeondelight/videoService-Test-a998b73763344c5bb0b819925de6b213?pvs=4) [🎮videoController 생성 및 Test](https://www.notion.so/yeondelight/videoController-Test-1c4da48b30324fdfaebab375f989e1b2?pvs=4)
 - @ MockMvc를 이용하여 연관객체에 의존하지 않고 테스트