### PR TITLE
[WEEK04] add MetadataDTO, Controller, Service

### DIFF
--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/VideoMetadataController.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/VideoMetadataController.java
@@ -1,0 +1,4 @@
+package org.hstack.vmeta.videoMetadata;
+
+public class VideoMetadataController {
+}

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/VideoMetadataDTO.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/VideoMetadataDTO.java
@@ -1,9 +1,6 @@
-package org.hstack.vmeta.videoMetadata.metadata;
+package org.hstack.vmeta.videoMetadata;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hstack.vmeta.videoMetadata.metadata.category.Category;
 import org.hstack.vmeta.videoMetadata.metadata.indexScript.IndexScript;
 import org.hstack.vmeta.videoMetadata.metadata.keyword.Keyword;
@@ -20,12 +17,13 @@ import java.util.List;
  * search, detailView 등 user에게 보여지는 영역용
  */
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class VideoMetadataDTO {
 
-    private Long Id;
+    private Long id;
 
     private String title;
 

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/VideoMetadataService.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/VideoMetadataService.java
@@ -1,0 +1,82 @@
+package org.hstack.vmeta.videoMetadata;
+
+import org.hstack.vmeta.videoMetadata.metadata.MetadataDTO;
+import org.hstack.vmeta.videoMetadata.metadata.MetadataService;
+import org.hstack.vmeta.videoMetadata.metadata.category.Category;
+import org.hstack.vmeta.videoMetadata.metadata.category.CategoryType;
+import org.hstack.vmeta.videoMetadata.video.VideoDTO;
+import org.hstack.vmeta.videoMetadata.video.VideoService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+public class VideoMetadataService {
+
+    @Autowired
+    private VideoService videoService;
+
+    @Autowired
+    private MetadataService metadataService;
+
+    /*
+     * search용 filtering
+     */
+    public List<VideoMetadataDTO> getByFilter(String title, String uploaderName, String keyword, String categoryType) {
+        // 전처리 - search filter에 따른 idSet 가져오기
+        CategoryType categoryTypeEnum = Category.apiVal2CategoryType.get(categoryType);
+        List<Long> idList = metadataService.getByFilter(title, uploaderName, keyword, categoryTypeEnum);
+
+        // main - idSet에 따라 video와 metadata 가져오기
+        List<VideoDTO> videoDTOList = videoService.getByIdList(idList);
+        List<MetadataDTO> metadataDTOList = metadataService.getByIdList(idList);
+
+        // 후처리 - video와 metadata merge
+        Map<Long, VideoMetadataDTO> resultMap = new HashMap<>();
+        for (VideoDTO v : videoDTOList) {
+            Long id = v.getId();
+            VideoMetadataDTO vmDTO = VideoMetadataDTO.builder()
+                    .id(v.getId())
+                    .path(v.getPath())
+                    .title(v.getTitle())
+                    .uploaderName(v.getUploaderName())
+                    .thumbnailPath(v.getThumbnailPath())
+                    .build();
+            resultMap.put(id, vmDTO);
+        }
+        for (MetadataDTO m : metadataDTOList) {
+            Long id = m.getId();
+            VideoMetadataDTO vmDTO = null;
+            if (resultMap.containsKey(id)) {
+                vmDTO = resultMap.get(id);
+                vmDTO.setNarrative(m.getNarrative());
+                vmDTO.setPresentation(m.getPresentation());
+                vmDTO.setLength(m.getLength());
+                vmDTO.setUploadDdate(m.getUploadDate());
+                vmDTO.setCategory(m.getCategory());
+                vmDTO.setScript(m.getScript());
+                vmDTO.setKeyword(m.getKeyword());
+                vmDTO.setIndexScript(m.getIndexScript());
+            } else {
+                vmDTO = VideoMetadataDTO.builder()
+                        .id(id)
+                        .title(m.getTitle())
+                        .uploaderName(m.getUploaderName())
+                        .narrative(m.getNarrative())
+                        .presentation(m.getPresentation())
+                        .length(m.getLength())
+                        .uploadDdate(m.getUploadDate())
+                        .category(m.getCategory())
+                        .script(m.getScript())
+                        .keyword(m.getKeyword())
+                        .indexScript(m.getIndexScript())
+                        .build();
+            }
+            resultMap.put(id, vmDTO);
+        }
+
+        // 반환 - map의 value만 추출
+        return resultMap.values().stream().toList();
+    }
+}

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/MetadataController.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/MetadataController.java
@@ -1,0 +1,50 @@
+package org.hstack.vmeta.videoMetadata.metadata;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/metadata")
+public class MetadataController {
+
+    @Autowired
+    private MetadataService metadataService;
+
+    private static String logMessage(String funcName, Long id, boolean result) {
+        return "[metadata] " + funcName + " #" + id + " : " + result;
+    }
+
+    @PostMapping
+    public ResponseEntity<?> saveMetadata(@RequestBody MetadataDTO metadataDTO) {
+        try{
+            Long videoId = metadataService.save(metadataDTO);
+            String body = logMessage("save", videoId, true);
+            return ResponseEntity.ok(body);
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    @PutMapping
+    public ResponseEntity<?> updateMetadata(@RequestBody MetadataDTO metadataDTO) {
+        try{
+            Long videoId = metadataService.update(metadataDTO);
+            String body = logMessage("update", videoId, true);
+            return ResponseEntity.ok(body);
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    @GetMapping("/delete")
+    public ResponseEntity<?> deleteMetadata(@RequestParam Long videoId) {
+        try {
+            metadataService.delete(videoId);
+            String body = logMessage("delete", videoId, true);
+            return ResponseEntity.ok(body);
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+}

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/MetadataDTO.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/MetadataDTO.java
@@ -1,7 +1,5 @@
 package org.hstack.vmeta.videoMetadata.metadata;
 
-
-import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,22 +8,16 @@ import org.hstack.vmeta.videoMetadata.metadata.category.Category;
 import org.hstack.vmeta.videoMetadata.metadata.indexScript.IndexScript;
 import org.hstack.vmeta.videoMetadata.metadata.keyword.Keyword;
 import org.hstack.vmeta.videoMetadata.metadata.narrative.Narrative;
-import org.hstack.vmeta.videoMetadata.metadata.narrative.NarrativeAttributeConverter;
 import org.hstack.vmeta.videoMetadata.metadata.presentation.Presentation;
-import org.hstack.vmeta.videoMetadata.metadata.presentation.PresentationAttributeConverter;
 import org.hstack.vmeta.videoMetadata.metadata.script.Script;
 import org.hstack.vmeta.videoMetadata.metadata.videoFrame.VideoFrame;
-import org.hstack.vmeta.videoMetadata.metadata.videoFrame.VideoFrameAttributeConverter;
 import org.hstack.vmeta.videoMetadata.metadata.videoType.VideoType;
-import org.hstack.vmeta.videoMetadata.metadata.videoType.VideoTypeAttributeConverter;
 
 import java.sql.Date;
 import java.sql.Time;
 import java.util.List;
 
-/*
- * extraction과 소통할 순수 Metadata
- */
+
 @Getter
 @Builder
 @NoArgsConstructor

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/MetadataDTO.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/MetadataDTO.java
@@ -59,4 +59,42 @@ public class MetadataDTO {
     private List<Keyword> keyword;
 
     private List<IndexScript> indexScript;
+
+    public static MetadataDTO toMetadataDTO(Metadata metadata) {
+        return MetadataDTO.builder()
+                .id(metadata.getId())
+                .title(metadata.getTitle())
+                .uploaderName(metadata.getUploaderName())
+                .narrative(metadata.getNarrative())
+                .presentation(metadata.getPresentation())
+                .length(metadata.getLength())
+                .uploadDate(metadata.getUploadDate())
+                .videoSize(metadata.getVideoSize())
+                .videoType(metadata.getVideoType())
+                .videoFrame(metadata.getVideoFrame())
+                .category(metadata.getCategory())
+                .script(metadata.getScript())
+                .keyword(metadata.getKeyword())
+                .indexScript(metadata.getIndexScript())
+                .build();
+    }
+
+    public Metadata toMetadata() {
+        return Metadata.builder()
+                .id(this.id)
+                .title(this.title)
+                .uploaderName(this.uploaderName)
+                .narrative(this.narrative)
+                .presentation(this.presentation)
+                .length(this.length)
+                .uploadDate(this.uploadDate)
+                .videoSize(this.videoSize)
+                .videoType(this.videoType)
+                .videoFrame(this.videoFrame)
+                .category(this.category)
+                .script(this.script)
+                .keyword(this.keyword)
+                .indexScript(this.indexScript)
+                .build();
+    }
 }

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/MetadataRepository.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/MetadataRepository.java
@@ -11,7 +11,7 @@ import java.util.Set;
 
 public interface MetadataRepository extends JpaRepository<Metadata, Long> {
 
-    Metadata save(Metadata video);
+    Metadata save(Metadata metadata);
 
     Optional<Metadata> findById(Long id);
 
@@ -24,7 +24,6 @@ public interface MetadataRepository extends JpaRepository<Metadata, Long> {
 
     @Query("select m from Metadata m join fetch m.category c where c.categoryType = :category")
     Set<MetadataMapping> findByCategory(@Param("category") CategoryType category);
-
 
     void deleteById(Long id);
 

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/MetadataService.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/MetadataService.java
@@ -1,0 +1,46 @@
+package org.hstack.vmeta.videoMetadata.metadata;
+
+import org.hstack.vmeta.videoMetadata.metadata.keyword.Keyword;
+import org.hstack.vmeta.videoMetadata.metadata.keyword.KeywordRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class MetadataService {
+
+    @Autowired
+    private MetadataRepository metadataRepository;
+
+    @Autowired
+    private KeywordRepository keywordRepository;
+
+    /*
+     * MetadataDTO를 Metadata로 변환 후 저장한다.
+     */
+    public Long save(MetadataDTO metadataDTO) {
+        return metadataRepository.save(metadataDTO.toMetadata()).getId();
+    }
+
+    /*
+     * 기존 MetadataDTO를 새로운 MetadataDTO로 교체한다.
+     * 아직은 Keyword만 교체 가능하기에 이에 한정해서 코드 작성 ('23.12.18)
+     * - 추후 업데이트 필요
+     * - front단에서 어떻게 keyword를 받아올것인가에 대한 고민 필요
+     */
+    public void update(MetadataDTO metadataDTO) {
+        Long videoId = metadataDTO.getId();
+        List<Keyword> newKeyword = metadataDTO.getKeyword();
+        keywordRepository.deleteByMid(videoId);
+        keywordRepository.saveAll(newKeyword);
+    }
+
+    /*
+     * MetadataDTO를 id를 기준으로 삭제한다.
+     */
+    public void delete(Long videoId) {
+        metadataRepository.deleteById(videoId);
+    }
+}

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/MetadataService.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/MetadataService.java
@@ -1,11 +1,15 @@
 package org.hstack.vmeta.videoMetadata.metadata;
 
+import org.hstack.vmeta.videoMetadata.metadata.category.CategoryType;
 import org.hstack.vmeta.videoMetadata.metadata.keyword.Keyword;
 import org.hstack.vmeta.videoMetadata.metadata.keyword.KeywordRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -26,6 +30,25 @@ public class MetadataService {
                 .stream()
                 .map(m -> MetadataDTO.toMetadataDTO(m))
                 .collect(Collectors.toList());
+    }
+
+    /*
+     * search용 filtering
+     * title, uploaderName, keyword, category가 포함된 idSet를 반환한다.
+     */
+    public List<Long> getByFilter(String title, String uploaderName, String keyword, CategoryType categoryType) {
+        List<MetadataMapping> idList = new ArrayList<>();
+        idList.addAll(metadataRepository.findByTitleContains(title));
+        idList.addAll(metadataRepository.findByUploaderNameContains(uploaderName));
+        idList.addAll(metadataRepository.findByKeywordContains(keyword));
+        idList.addAll(metadataRepository.findByCategory(categoryType));
+
+        Set<Long> idSet = new HashSet<>();
+        for (MetadataMapping mm : idList) {
+            idSet.add(mm.getId());
+        }
+
+        return idSet.stream().toList();
     }
 
     /*

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/MetadataService.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/MetadataService.java
@@ -41,11 +41,12 @@ public class MetadataService {
      * - 추후 업데이트 필요
      * - front단에서 어떻게 keyword를 받아올것인가에 대한 고민 필요
      */
-    public void update(MetadataDTO metadataDTO) {
+    public Long update(MetadataDTO metadataDTO) {
         Long videoId = metadataDTO.getId();
         List<Keyword> newKeyword = metadataDTO.getKeyword();
         keywordRepository.deleteByMid(videoId);
         keywordRepository.saveAll(newKeyword);
+        return videoId;
     }
 
     /*

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/MetadataService.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/MetadataService.java
@@ -18,6 +18,17 @@ public class MetadataService {
     private KeywordRepository keywordRepository;
 
     /*
+     * 특정 id list에 해당하는 Metadata를 가져온다.
+     * videoMetadata에서 써먹기 위함
+     */
+    public List<MetadataDTO> getByIdList(List<Long> idList) {
+        return metadataRepository.findAllById(idList)
+                .stream()
+                .map(m -> MetadataDTO.toMetadataDTO(m))
+                .collect(Collectors.toList());
+    }
+
+    /*
      * MetadataDTO를 Metadata로 변환 후 저장한다.
      */
     public Long save(MetadataDTO metadataDTO) {

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/category/Category.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/category/Category.java
@@ -35,7 +35,7 @@ public class Category {
      * << categoryType Matching >>
      * - 한국 표준 십진분류법에 맞게 ETRI TTA 표준 태그셋 매칭
      */
-    public final static Map<String, CategoryType> categoryTypeMap = new HashMap<String, CategoryType>() {
+    public final static Map<String, CategoryType> apiVal2CategoryType = new HashMap<String, CategoryType>() {
         {
             put("TMI_HW", CategoryType.IT);
             put("TMI_SW", CategoryType.IT);
@@ -164,7 +164,7 @@ public class Category {
     };
 
     // 사실 여기서 쓸건 아닌데 나중에 다른 모듈 할때 복붙 편하라고...
-    public final static Map<CategoryType, String> categoryMap = new HashMap<CategoryType, String>() {
+    public final static Map<CategoryType, String> category2Str = new HashMap<CategoryType, String>() {
         {
             put(CategoryType.POLITICS, "행정");
             put(CategoryType.ECONOMY, "경제");

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/keyword/Keyword.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/keyword/Keyword.java
@@ -3,10 +3,12 @@ package org.hstack.vmeta.videoMetadata.metadata.keyword;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name="keyword")
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/keyword/Keyword.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/keyword/Keyword.java
@@ -15,8 +15,19 @@ public class Keyword {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column
     private String keyword;
+
+    @Column
     private float perc;
+
+    @Column
     private boolean expose;
+
+    @Column
     private boolean autocreated;
+
+    @Column(name="metadata_id")
+    private Long mid;
 }

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/keyword/KeywordRepository.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/keyword/KeywordRepository.java
@@ -1,0 +1,10 @@
+package org.hstack.vmeta.videoMetadata.metadata.keyword;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface KeywordRepository extends JpaRepository<Keyword, Long> {
+
+    void deleteByMid(Long mid);
+}

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/keyword/KeywordRepository.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/metadata/keyword/KeywordRepository.java
@@ -4,7 +4,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface KeywordRepository extends JpaRepository<Keyword, Long> {
+
+    List<Keyword> saveAll(List<Keyword>keywordList);
 
     void deleteByMid(Long mid);
 }

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/video/VideoController.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/video/VideoController.java
@@ -13,6 +13,10 @@ public class VideoController {
     @Autowired
     private VideoService videoService;
 
+    private static String logMessage(String funcName, Long id, boolean result) {
+        return "[video] " + funcName + " #" + id + " : " + result;
+    }
+
     @GetMapping
     public ResponseEntity<?> getAllVideo() {
         try {
@@ -27,7 +31,7 @@ public class VideoController {
     public ResponseEntity<?> saveVideo(@RequestBody VideoDTO videoDTO) {
         try {
             Long videoId = videoService.save(videoDTO);
-            String body = "save video #" + videoId + " succeed.";
+            String body = logMessage("save", videoId, true);
             return ResponseEntity.ok(body);
         } catch (Exception e) {
             return ResponseEntity.internalServerError().build();
@@ -38,7 +42,7 @@ public class VideoController {
     public ResponseEntity<?> deleteVideo(@RequestParam Long videoId) {
         try {
             videoService.delete(videoId);
-            String body = "delete video #" + videoId + " succeed.";
+            String body = logMessage("delete", videoId, true);
             return ResponseEntity.ok(body);
         } catch (Exception e) {
             return ResponseEntity.internalServerError().build();

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/video/VideoDTO.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/video/VideoDTO.java
@@ -21,7 +21,7 @@ public class VideoDTO {
 
     private String thumbnailPath;
 
-    public static VideoDTO video2VideoDTO(Video video) {
+    public static VideoDTO toVideoDTO(Video video) {
         return VideoDTO.builder()
                 .id(video.getId())
                 .title(video.getTitle())
@@ -30,7 +30,7 @@ public class VideoDTO {
                 .build();
     }
 
-    public Video videoDTO2Video() {
+    public Video toVideo() {
         return Video.builder()
                 .title(this.title)
                 .uploaderName(this.uploaderName)

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/video/VideoDTO.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/video/VideoDTO.java
@@ -15,6 +15,8 @@ public class VideoDTO {
 
     private Long id;
 
+    private String path;
+
     private String title;
 
     private String uploaderName;

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/video/VideoService.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/video/VideoService.java
@@ -19,7 +19,7 @@ public class VideoService {
     public List<VideoDTO> getAll() {
         return videoRepository.findAll()
                 .stream()
-                .map(v -> VideoDTO.video2VideoDTO(v))
+                .map(v -> VideoDTO.toVideoDTO(v))
                 .collect(Collectors.toList());
     }
 
@@ -27,7 +27,7 @@ public class VideoService {
      * videoDTO를 video로 변환 후 저장한다.
      */
     public Long save(VideoDTO videoDTO) {
-        return videoRepository.save(videoDTO.videoDTO2Video()).getId();
+        return videoRepository.save(videoDTO.toVideo()).getId();
     }
 
     /*

--- a/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/video/VideoService.java
+++ b/videoMetadata/src/main/java/org/hstack/vmeta/videoMetadata/video/VideoService.java
@@ -1,5 +1,6 @@
 package org.hstack.vmeta.videoMetadata.video;
 
+import org.hstack.vmeta.videoMetadata.metadata.MetadataDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -18,6 +19,17 @@ public class VideoService {
      */
     public List<VideoDTO> getAll() {
         return videoRepository.findAll()
+                .stream()
+                .map(v -> VideoDTO.toVideoDTO(v))
+                .collect(Collectors.toList());
+    }
+
+    /*
+     * 특정 id list에 해당하는 Video를 가져온다.
+     * videoMetadata에서 써먹기 위함
+     */
+    public List<VideoDTO> getByIdList(List<Long> idList) {
+        return videoRepository.findAllById(idList)
                 .stream()
                 .map(v -> VideoDTO.toVideoDTO(v))
                 .collect(Collectors.toList());

--- a/videoMetadata/src/test/java/org/hstack/vmeta/videoMetadata/VideoMetadataServiceTest.java
+++ b/videoMetadata/src/test/java/org/hstack/vmeta/videoMetadata/VideoMetadataServiceTest.java
@@ -1,0 +1,155 @@
+package org.hstack.vmeta.videoMetadata;
+
+import org.hstack.vmeta.videoMetadata.metadata.MetadataDTO;
+import org.hstack.vmeta.videoMetadata.metadata.MetadataService;
+import org.hstack.vmeta.videoMetadata.metadata.category.Category;
+import org.hstack.vmeta.videoMetadata.metadata.category.CategoryType;
+import org.hstack.vmeta.videoMetadata.metadata.keyword.Keyword;
+import org.hstack.vmeta.videoMetadata.video.VideoDTO;
+import org.hstack.vmeta.videoMetadata.video.VideoService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class VideoMetadataServiceTest {
+
+    @Mock
+    private VideoService videoService;
+
+    @Mock
+    private MetadataService metadataService;
+
+    @InjectMocks
+    private VideoMetadataService videoMetadataService;
+
+    @Test
+    @DisplayName("검색 조건으로 메타데이터 조회 - 제목")
+    void getByFilterTitle() {
+        // given
+        String findText = "test";
+
+        List<VideoDTO> videoList = new ArrayList<>();
+        videoList.add(VideoDTO.builder().id(1L).title(findText).build());
+
+        List<MetadataDTO> metadataList = new ArrayList<>();
+        metadataList.add(MetadataDTO.builder().id(1L).title(findText).build());
+
+        List<Long> savedIdList = new ArrayList<>();
+        savedIdList.add(1L);
+
+        // mocking
+        given(metadataService.getByFilter(findText, null, null, null)).willReturn(savedIdList);
+        given(videoService.getByIdList(savedIdList)).willReturn(videoList);
+        given(metadataService.getByIdList(savedIdList)).willReturn(metadataList);
+
+        // when
+        List<VideoMetadataDTO> resList = videoMetadataService.getByFilter(
+                findText,
+                null,
+                null,
+                null);
+
+        // then
+        assertThat(resList.size()).isEqualTo(savedIdList.size());
+    }
+
+    @Test
+    @DisplayName("검색 조건으로 메타데이터 조회 - 업로더")
+    void getByFilterUploaderName() {
+        // given
+        String findText = "test";
+
+        List<VideoDTO> videoList = new ArrayList<>();
+        videoList.add(VideoDTO.builder().id(1L).uploaderName(findText).build());
+
+        List<MetadataDTO> metadataList = new ArrayList<>();
+        metadataList.add(MetadataDTO.builder().id(1L).uploaderName(findText).build());
+
+        List<Long> savedIdList = new ArrayList<>();
+        savedIdList.add(1L);
+
+        // mocking
+        given(metadataService.getByFilter(null, findText, null, null)).willReturn(savedIdList);
+        given(videoService.getByIdList(savedIdList)).willReturn(videoList);
+        given(metadataService.getByIdList(savedIdList)).willReturn(metadataList);
+
+        // when
+        List<VideoMetadataDTO> resList = videoMetadataService.getByFilter(
+                null,
+                findText,
+                null,
+                null);
+
+        // then
+        assertThat(resList.size()).isEqualTo(savedIdList.size());
+    }
+
+    @Test
+    @DisplayName("검색 조건으로 메타데이터 조회 - 키워드")
+    void getByFilterKeyword() {
+        // given
+        String findText = "test";
+        List<Keyword> keywordList = new ArrayList<>();
+        keywordList.add(Keyword.builder().keyword(findText).build());
+
+        List<MetadataDTO> metadataList = new ArrayList<>();
+        metadataList.add(MetadataDTO.builder().id(1L).keyword(keywordList).build());
+
+        List<Long> savedIdList = new ArrayList<>();
+        savedIdList.add(1L);
+
+        // mocking
+        given(metadataService.getByFilter(null, null, findText, null)).willReturn(savedIdList);
+        given(metadataService.getByIdList(savedIdList)).willReturn(metadataList);
+
+        // when
+        List<VideoMetadataDTO> resList = videoMetadataService.getByFilter(
+                null,
+                null,
+                findText,
+                null);
+
+        // then
+        assertThat(resList.size()).isEqualTo(savedIdList.size());
+    }
+
+    @Test
+    @DisplayName("검색 조건으로 메타데이터 조회 - 카테고리")
+    void getByFilterCategory() {
+        // given
+        String findText = "TMI_HW";
+        CategoryType categoryType = Category.apiVal2CategoryType.get(findText);
+        List<Category> categoryList = new ArrayList<>();
+        categoryList.add(Category.builder().categoryType(categoryType).build());
+
+        List<MetadataDTO> metadataList = new ArrayList<>();
+        metadataList.add(MetadataDTO.builder().id(1L).category(categoryList).build());
+
+        List<Long> savedIdList = new ArrayList<>();
+        savedIdList.add(1L);
+
+        // mocking
+        given(metadataService.getByFilter(null, null, null, categoryType)).willReturn(savedIdList);
+        given(metadataService.getByIdList(savedIdList)).willReturn(metadataList);
+
+        // when
+        List<VideoMetadataDTO> resList = videoMetadataService.getByFilter(
+                null,
+                null,
+                null,
+                findText);
+
+        // then
+        assertThat(resList.size()).isEqualTo(savedIdList.size());
+    }
+}

--- a/videoMetadata/src/test/java/org/hstack/vmeta/videoMetadata/metadata/MetadataControllerTest.java
+++ b/videoMetadata/src/test/java/org/hstack/vmeta/videoMetadata/metadata/MetadataControllerTest.java
@@ -1,6 +1,9 @@
-package org.hstack.vmeta.videoMetadata.video;
+package org.hstack.vmeta.videoMetadata.metadata;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hstack.vmeta.videoMetadata.video.VideoController;
+import org.hstack.vmeta.videoMetadata.video.VideoDTO;
+import org.hstack.vmeta.videoMetadata.video.VideoService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,80 +16,42 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
-@WebMvcTest(VideoController.class)
-class VideoControllerTest {
+@WebMvcTest(MetadataController.class)
+class MetadataControllerTest {
 
     @Autowired
     MockMvc mockMvc;
 
     @MockBean
-    VideoService videoService;
+    MetadataService metadataService;
 
     @Autowired
     private ObjectMapper objectMapper;
 
-    final String baseUrl = "/video";
+    final String baseUrl = "/metadata";
 
     @BeforeEach
     void init() {
     }
 
     @Test
-    @DisplayName("전체 비디오 조회")
-    void getAllVideo() throws Exception{
+    @DisplayName("메타데이터 저장")
+    void saveMetadata() throws Exception {
         // given
-        List<VideoDTO> savedVideoDTOList = new ArrayList<>();
-        savedVideoDTOList.add(VideoDTO.builder()
-                .id(1L)
-                .title("testTitle1")
-                .uploaderName("testUploader1")
-                .thumbnailPath("/test/1L/path.mp4")
-                .build());
-        savedVideoDTOList.add(VideoDTO.builder()
-                .id(2L)
-                .title("testTitle2")
-                .uploaderName("testUploader2")
-                .thumbnailPath("/test/2L/path.mp4")
-                .build());
-
-        // mocking
-        given(videoService.getAll()).willReturn(savedVideoDTOList);
-
-        // when
-        final ResultActions actions =
-                mockMvc.perform(
-                        get(baseUrl)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .accept(MediaType.APPLICATION_JSON)
-                                .characterEncoding("UTF-8")
-                );
-
-        // then
-        actions.andExpect(status().isOk())
-                .andExpect(jsonPath("$[0]").exists())
-                .andExpect(jsonPath("$[1]").exists())
-                .andDo(print());
-    }
-
-    @Test
-    @DisplayName("비디오 저장")
-    void saveVideo() throws Exception {
-        // given
-        VideoDTO videoDTO = VideoDTO.builder().title("testTitle").build();
+        MetadataDTO metadataDTO = MetadataDTO.builder().build();
         Long expectVideoId = 0L;
 
         // mocking
-        given(videoService.save(videoDTO)).willReturn(expectVideoId);
+        given(metadataService.save(metadataDTO)).willReturn(expectVideoId);
 
         // when
         final ResultActions actions =
@@ -94,7 +59,7 @@ class VideoControllerTest {
                         post(baseUrl)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .accept(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(videoDTO))
+                                .content(objectMapper.writeValueAsString(metadataDTO))
                                 .characterEncoding("UTF-8")
                 );
 
@@ -104,25 +69,50 @@ class VideoControllerTest {
     }
 
     @Test
-    @DisplayName("비디오 삭제")
-    void deleteVideo() throws Exception{
+    @DisplayName("메타데이터 업데이트 - 키워드")
+    void updateMetadata() throws Exception {
         // given
-        Long videoId = 1L;
+        MetadataDTO metadataDTO = MetadataDTO.builder().build();
+        Long expectVideoId = 0L;
 
         // mocking
+        given(metadataService.update(metadataDTO)).willReturn(expectVideoId);
 
         // when
         final ResultActions actions =
                 mockMvc.perform(
-                        get(baseUrl + "/delete")
+                        post(baseUrl)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .accept(MediaType.APPLICATION_JSON)
-                                .param("videoId", String.valueOf(videoId))
+                                .content(objectMapper.writeValueAsString(metadataDTO))
                                 .characterEncoding("UTF-8")
                 );
 
         // then
         actions.andExpect(status().isOk())
                 .andDo(print());
+    }
+
+    @Test
+    @DisplayName("메타데이터 삭제")
+    void deleteMetadata() throws Exception{
+            // given
+            Long videoId = 1L;
+
+            // mocking
+
+            // when
+            final ResultActions actions =
+                    mockMvc.perform(
+                            get(baseUrl + "/delete")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .accept(MediaType.APPLICATION_JSON)
+                                    .param("videoId", String.valueOf(videoId))
+                                    .characterEncoding("UTF-8")
+                    );
+
+            // then
+            actions.andExpect(status().isOk())
+                    .andDo(print());
     }
 }

--- a/videoMetadata/src/test/java/org/hstack/vmeta/videoMetadata/metadata/MetadataServiceTest.java
+++ b/videoMetadata/src/test/java/org/hstack/vmeta/videoMetadata/metadata/MetadataServiceTest.java
@@ -1,0 +1,139 @@
+package org.hstack.vmeta.videoMetadata.metadata;
+
+import jakarta.transaction.Transactional;
+import org.hstack.vmeta.videoMetadata.metadata.keyword.Keyword;
+import org.hstack.vmeta.videoMetadata.metadata.keyword.KeywordRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MetadataServiceTest {
+
+    @Mock
+    private MetadataRepository metadataRepository;
+
+    @Mock
+    private KeywordRepository keywordRepository;
+
+    @InjectMocks
+    private MetadataService metadataService;
+
+    @BeforeEach
+    void beforeEach() {
+        keywordRepository.deleteAll();
+        metadataRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("특정 메타데이터 조회")
+    void getByIdList() {
+        // given
+        List<Long> idList = new ArrayList<>();
+        idList.add(1L);
+        idList.add(2L);
+
+        List<Metadata> videoList = new ArrayList<>();
+        videoList.add(Metadata.builder().id(1L).build());
+        videoList.add(Metadata.builder().id(2L).build());
+        videoList.add(Metadata.builder().id(3L).build());
+
+        List<Metadata> savedList = videoList.subList(0, idList.size());
+
+        // mocking
+        given(metadataRepository.findAllById(idList)).willReturn(savedList);
+
+        // when
+        List<MetadataDTO> resList = metadataService.getByIdList(idList);
+
+        // then
+        assertThat(resList.size()).isEqualTo(idList.size());
+    }
+
+    @Test
+    @DisplayName("메타데이터 저장")
+    @Transactional
+    void save() {
+        // given
+        MetadataDTO metadataDTO = MetadataDTO.builder().build();
+        Metadata saveMetadata = metadataDTO.toMetadata();
+
+        // mocking
+        given(metadataRepository.save(any())).willReturn(metadataDTO.toMetadata());
+
+        // when
+        Long newId = metadataService.save(metadataDTO);
+
+        // then
+        assertThat(newId).isEqualTo(saveMetadata.getId());
+    }
+
+    @Test
+    @DisplayName("메타데이터 수정 - 키워드")
+    @Transactional
+    void update() {
+        // given
+        Long mid = 0L;
+
+        List<Long> idList = new ArrayList<>();
+        idList.add(mid);
+
+        List<Keyword> newKeywordList = new ArrayList<>();
+        newKeywordList.add(Keyword.builder().id(10L).mid(mid).build());
+        newKeywordList.add(Keyword.builder().id(20L).mid(mid).build());
+
+        MetadataDTO newMetadataDTO = MetadataDTO.builder()
+                .id(mid)
+                .keyword(newKeywordList)
+                .build();
+        
+        List<Metadata> savedMetadataList = new ArrayList<>();
+        savedMetadataList.add(newMetadataDTO.toMetadata());
+
+
+        // mocking
+        given(keywordRepository.saveAll(newKeywordList)).willReturn(newKeywordList);
+        given(metadataRepository.findAllById(idList)).willReturn(savedMetadataList);
+
+        // when
+        metadataService.update(newMetadataDTO);
+
+        List<Keyword> keywordList = metadataService.getByIdList(idList)
+                .get(0)
+                .getKeyword();
+
+        // then
+        assertThat(keywordList.size()).isEqualTo(newMetadataDTO.getKeyword().size());
+        for (int i = 0; i < keywordList.size(); i++) {
+            assertThat(keywordList.get(i).getId()).isEqualTo(newKeywordList.get(i).getId());
+        }
+    }
+
+    @Test
+    @DisplayName("메타데이터 삭제")
+    @Transactional
+    void delete() {
+        // given
+        Long videoId = 1L;
+
+        // mocking
+
+        // when
+        metadataService.delete(videoId);
+
+        // then
+        verify(metadataRepository).deleteById(videoId);
+    }
+}

--- a/videoMetadata/src/test/java/org/hstack/vmeta/videoMetadata/metadata/MetadataServiceTest.java
+++ b/videoMetadata/src/test/java/org/hstack/vmeta/videoMetadata/metadata/MetadataServiceTest.java
@@ -1,6 +1,8 @@
 package org.hstack.vmeta.videoMetadata.metadata;
 
 import jakarta.transaction.Transactional;
+import org.hstack.vmeta.videoMetadata.metadata.category.Category;
+import org.hstack.vmeta.videoMetadata.metadata.category.CategoryType;
 import org.hstack.vmeta.videoMetadata.metadata.keyword.Keyword;
 import org.hstack.vmeta.videoMetadata.metadata.keyword.KeywordRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,7 +14,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -60,6 +64,155 @@ class MetadataServiceTest {
 
         // then
         assertThat(resList.size()).isEqualTo(idList.size());
+    }
+
+    @Test
+    @DisplayName("검색 조건으로 메타데이터 조회 - 제목")
+    void getByFilterTitle() {
+        // given
+        String findText = "test";
+
+        List<Metadata> videoList = new ArrayList<>();
+        videoList.add(Metadata.builder().id(1L).title(findText).build());
+        videoList.add(Metadata.builder().id(2L).title(findText).build());
+        videoList.add(Metadata.builder().id(3L).title("user").build());
+
+        Set<MetadataMapping> savedIdList = new HashSet<>();
+        savedIdList.add(new MetadataMapping() {
+            @Override
+            public Long getId() {
+                return 1L;
+            }
+        });
+        savedIdList.add(new MetadataMapping() {
+            @Override
+            public Long getId() {
+                return 2L;
+            }
+        });
+
+        // mocking
+        given(metadataRepository.findByTitleContains(findText)).willReturn(savedIdList);
+
+        // when
+        List<Long> resList = metadataService.getByFilter(findText, null, null, null);
+
+        // then
+        assertThat(resList.size()).isEqualTo(savedIdList.size());
+    }
+
+    @Test
+    @DisplayName("검색 조건으로 메타데이터 조회 - 업로더")
+    void getByFilterUploaderName() {
+        // given
+        String findText = "test";
+
+        List<Metadata> videoList = new ArrayList<>();
+        videoList.add(Metadata.builder().id(1L).uploaderName(findText).build());
+        videoList.add(Metadata.builder().id(2L).uploaderName(findText).build());
+        videoList.add(Metadata.builder().id(3L).uploaderName("user").build());
+
+        Set<MetadataMapping> savedIdList = new HashSet<>();
+        savedIdList.add(new MetadataMapping() {
+            @Override
+            public Long getId() {
+                return 1L;
+            }
+        });
+        savedIdList.add(new MetadataMapping() {
+            @Override
+            public Long getId() {
+                return 2L;
+            }
+        });
+
+        // mocking
+        given(metadataRepository.findByUploaderNameContains(findText)).willReturn(savedIdList);
+
+        // when
+        List<Long> resList = metadataService.getByFilter(null, findText, null, null);
+
+        // then
+        assertThat(resList.size()).isEqualTo(savedIdList.size());
+    }
+
+    @Test
+    @DisplayName("검색 조건으로 메타데이터 조회 - 키워드")
+    void getByFilterKeyword() {
+        // given
+        String findText = "test";
+        List<Keyword> keywordList1 = new ArrayList<>();
+        keywordList1.add(Keyword.builder().keyword(findText).build());
+        List<Keyword> keywordList2 = new ArrayList<>();
+        keywordList2.add(Keyword.builder().keyword("user").build());
+
+        List<Metadata> videoList = new ArrayList<>();
+        videoList.add(Metadata.builder().id(1L).keyword(keywordList1).build());
+        videoList.add(Metadata.builder().id(2L).keyword(keywordList1).build());
+        videoList.add(Metadata.builder().id(3L).keyword(keywordList2).build());
+
+        Set<MetadataMapping> savedIdList = new HashSet<>();
+        savedIdList.add(new MetadataMapping() {
+            @Override
+            public Long getId() {
+                return 1L;
+            }
+        });
+        savedIdList.add(new MetadataMapping() {
+            @Override
+            public Long getId() {
+                return 2L;
+            }
+        });
+
+        // mocking
+        given(metadataRepository.findByKeywordContains(findText)).willReturn(savedIdList);
+
+        // when
+        List<Long> resList = metadataService.getByFilter(null, null, findText, null);
+
+        // then
+        assertThat(resList.size()).isEqualTo(savedIdList.size());
+    }
+
+
+    @Test
+    @DisplayName("검색 조건으로 메타데이터 조회 - 카테고리")
+    void getByFilterCategoryType() {
+        // given
+        CategoryType findType = CategoryType.IT;
+        List<Category> categoryList1 = new ArrayList<>();
+        categoryList1.add(Category.builder().categoryType(findType).build());
+        List<Category> categoryList2 = new ArrayList<>();
+        categoryList2.add(Category.builder().categoryType(CategoryType.ART).build());
+
+        List<Metadata> videoList = new ArrayList<>();
+        videoList.add(Metadata.builder().id(1L).category(categoryList1).build());
+        videoList.add(Metadata.builder().id(2L).category(categoryList1).build());
+        videoList.add(Metadata.builder().id(3L).category(categoryList2).build());
+
+        Set<MetadataMapping> savedIdList = new HashSet<>();
+        savedIdList.add(new MetadataMapping() {
+            @Override
+            public Long getId() {
+                return 1L;
+            }
+        });
+        savedIdList.add(new MetadataMapping() {
+            @Override
+            public Long getId() {
+                return 2L;
+            }
+        });
+
+        // mocking
+        given(metadataRepository.findByCategory(findType)).willReturn(savedIdList);
+
+        // when
+        List<Long> resList = metadataService.getByFilter(null, null, null, findType);
+
+        // then
+        assertThat(resList.size()).isEqualTo(savedIdList.size());
     }
 
     @Test

--- a/videoMetadata/src/test/java/org/hstack/vmeta/videoMetadata/metadata/keyword/KeywordRepositoryTest.java
+++ b/videoMetadata/src/test/java/org/hstack/vmeta/videoMetadata/metadata/keyword/KeywordRepositoryTest.java
@@ -1,0 +1,124 @@
+package org.hstack.vmeta.videoMetadata.metadata.keyword;
+
+import jakarta.transaction.Transactional;
+import org.hstack.vmeta.videoMetadata.metadata.Metadata;
+import org.hstack.vmeta.videoMetadata.metadata.MetadataRepository;
+import org.hstack.vmeta.videoMetadata.metadata.narrative.Narrative;
+import org.hstack.vmeta.videoMetadata.metadata.presentation.Presentation;
+import org.hstack.vmeta.videoMetadata.metadata.videoFrame.VideoFrame;
+import org.hstack.vmeta.videoMetadata.metadata.videoType.VideoType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.sql.Date;
+import java.sql.Time;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class KeywordRepositoryTest {
+
+    @Autowired
+    private KeywordRepository keywordRepository;
+
+    @Autowired
+    private MetadataRepository metadataRepository;
+
+    @BeforeEach
+    void 초기화() {
+        keywordRepository.deleteAll();
+        metadataRepository.deleteAll();
+        metadataRepository.save(Metadata.builder()
+                .id(1L)
+                .narrative(Narrative.APPLICATION)
+                .presentation(Presentation.DYNAMIC)
+                .length(new Time(0, 30, 10))
+                .uploadDate(new Date(2023, 12, 5))
+                .videoSize(0L)
+                .videoType(VideoType.MP4)
+                .videoFrame(VideoFrame.FPS24)
+                .build());
+        metadataRepository.save(Metadata.builder()
+                .id(2L)
+                .narrative(Narrative.APPLICATION)
+                .presentation(Presentation.DYNAMIC)
+                .length(new Time(0, 30, 10))
+                .uploadDate(new Date(2023, 12, 5))
+                .videoSize(0L)
+                .videoType(VideoType.MP4)
+                .videoFrame(VideoFrame.FPS24)
+                .build());
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("Keyword List 저장")
+    void saveAll() {
+        // given
+        List<Keyword> keywordList = new ArrayList<>();
+        keywordList.add(Keyword.builder()
+                .keyword("testKeyword")
+                .perc(0.5F)
+                .expose(true)
+                .autocreated(true)
+                .mid(1L)
+                .build());
+        keywordList.add(Keyword.builder()
+                .keyword("testKeyword2")
+                .perc(0.3F)
+                .expose(true)
+                .autocreated(true)
+                .mid(1L)
+                .build());
+
+        // when
+        keywordRepository.saveAll(keywordList);
+
+        // then
+        assertThat(keywordRepository.findAll().size()).isEqualTo(keywordList.size());
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("mid로 Keyword 삭제")
+    void deleteByMid() {
+        // given
+        List<Keyword> keywordList = new ArrayList<>();
+        keywordList.add(Keyword.builder()
+                .keyword("testKeyword")
+                .perc(0.5F)
+                .expose(true)
+                .autocreated(true)
+                .mid(1L)
+                .build());
+        keywordList.add(Keyword.builder()
+                .keyword("testKeyword2")
+                .perc(0.3F)
+                .expose(true)
+                .autocreated(true)
+                .mid(1L)
+                .build());
+        keywordList.add(Keyword.builder()
+                .keyword("testKeyword3")
+                .perc(0.2F)
+                .expose(true)
+                .autocreated(true)
+                .mid(2L)
+                .build());
+
+        // when
+        keywordRepository.saveAll(keywordList);
+        keywordRepository.deleteByMid(1L);
+
+        // then
+        assertThat(keywordRepository.findAll().size()).isEqualTo(1);
+    }
+}

--- a/videoMetadata/src/test/java/org/hstack/vmeta/videoMetadata/video/VideoServiceTest.java
+++ b/videoMetadata/src/test/java/org/hstack/vmeta/videoMetadata/video/VideoServiceTest.java
@@ -65,10 +65,10 @@ class VideoServiceTest {
     void save() {
         // given
         VideoDTO videoDTO = VideoDTO.builder().title("testTitle").build();
-        Video saveVideo = videoDTO.videoDTO2Video();
+        Video saveVideo = videoDTO.toVideo();
 
         // mocking
-        given(videoRepository.save(any())).willReturn(videoDTO.videoDTO2Video());
+        given(videoRepository.save(any())).willReturn(videoDTO.toVideo());
 
         // when
         Long newId = videoService.save(videoDTO);

--- a/videoMetadata/src/test/java/org/hstack/vmeta/videoMetadata/video/VideoServiceTest.java
+++ b/videoMetadata/src/test/java/org/hstack/vmeta/videoMetadata/video/VideoServiceTest.java
@@ -60,6 +60,31 @@ class VideoServiceTest {
     }
 
     @Test
+    @DisplayName("특정 비디오 조회")
+    void getByIdList() {
+        // given
+        List<Long> idList = new ArrayList<>();
+        idList.add(1L);
+        idList.add(2L);
+
+        List<Video> videoList = new ArrayList<>();
+        videoList.add(Video.builder().id(1L).title("testTitle1").build());
+        videoList.add(Video.builder().id(2L).title("testTitle2").build());
+        videoList.add(Video.builder().id(3L).title("testTitle3").build());
+
+        List<Video> savedList = videoList.subList(0, idList.size());
+
+        // mocking
+        given(videoRepository.findAllById(idList)).willReturn(savedList);
+
+        // when
+        List<VideoDTO> resList = videoService.getByIdList(idList);
+
+        // then
+        assertThat(resList.size()).isEqualTo(idList.size());
+    }
+
+    @Test
     @DisplayName("비디오 저장")
     @Transactional
     void save() {


### PR DESCRIPTION
###  [12월 3주차 정기] 12/18 ~ 12/21

<hr/>

**1. MetadataService 생성 및 Test**
- MetadataDTO 생성
- MetadataService 생성
 → [🛎️metadataService 생성](https://www.notion.so/yeondelight/metadataService-6559e83da59b4d30aec7578011f3a68c?pvs=4) [🛎️metadataService Test](https://www.notion.so/yeondelight/metadataService-Test-5cf04c7afa3f4bc2b2e254c84db6043c?pvs=4)
    - getById(idList) : idList에 해당하는 MetadataDTO List 반환
    - getByFilter(...) : detail search시 주어지는 filter에 부합하는 MetadataEntity의 id List 반환
    - update() : keyword의 정보 변경 적용
    - save(), delete()


<br/>

**2. MetadataController 생성**
 → [🎮metadataController 생성 및 Test](https://www.notion.so/yeondelight/metadataController-Test-f24ce00c06804557bb448c788a7f8e66?pvs=4)
 - 이전 videoController와 거의 유사.
 - logMessage() 생성 : videoController, metadataController 내 body  message 생성을 위함

<br/>

**3. videoMetadataService 생성 및 Test**
 → [🛎️videoMetadataService 생성 및 Test](https://www.notion.so/yeondelight/videoMetadataService-Test-3e150dfb64534d79bdeb54ed5c929e02?pvs=4)
 - VideoDTO 내 path 추가 : Entity와 동일하게 변경
 - getByFilter() 생성 : detail search에서의 filter 적용 위